### PR TITLE
Fix: add missing name forwarding for Periodic runner

### DIFF
--- a/periodic.go
+++ b/periodic.go
@@ -38,3 +38,7 @@ func (r *periodic) Run(ctx context.Context) (err error) {
 		time.Sleep(time.Until(start.Add(r.opts.Period)))
 	}
 }
+
+func (r *periodic) name() string {
+	return nameOfRunnable(r.runnable)
+}


### PR DESCRIPTION
In the logs, the name should from the actual runner, not the wrappers like Periodic/Recover.