### PR TITLE
Allow runnables to be initialized/cleaned when run in group

### DIFF
--- a/group.go
+++ b/group.go
@@ -13,7 +13,7 @@ func Group(runnables ...Runnable) *GroupRunner {
 
 	for _, runnable := range runnables {
 		g.containers = append(g.containers, &container{
-			runnable: Recover(runnable),
+			runnable: runnable,
 		})
 	}
 
@@ -33,10 +33,18 @@ func (g *GroupRunner) Run(ctx context.Context) error {
 	dying := make(chan struct{}, totalCount)
 	completedChan := make(chan *container, totalCount)
 
-	// start the runnables in Go routines.
+	// start the runnables in Go routines (if implemented).
+	for _, container := range g.containers {
+		err := container.init(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	// run the runnables in Go routines.
 	for _, c := range g.containers {
 		c.launch(ctx, completedChan, dying)
-		log.Infof("group: %s started\n", c.name())
+		log.Infof("group: %s running\n", c.name())
 	}
 
 	// block until group is cancelled, or a runnable dies.
@@ -46,6 +54,7 @@ func (g *GroupRunner) Run(ctx context.Context) error {
 		cancelFunc()
 	}
 
+	// graceful shutdown
 	deadline := time.After(g.ShutdownTimeout)
 	completedCount := 0
 	shutdown := false
@@ -66,9 +75,13 @@ func (g *GroupRunner) Run(ctx context.Context) error {
 		}
 
 		if completedCount == totalCount {
-			log.Infof("group: shutdown complete")
 			break
 		}
+	}
+
+	// start the runnables in Go routines (if implemented).
+	for _, container := range reverseContainer(g.containers) {
+		container.cleanup(ctx)
 	}
 
 	errs := []string{}
@@ -83,8 +96,9 @@ func (g *GroupRunner) Run(ctx context.Context) error {
 		if c.err != nil && c.err != context.Canceled {
 			errs = append(errs, fmt.Sprintf("%s crashed with %+v", c.name(), c.err))
 		}
-
 	}
+
+	log.Infof("group: shutdown complete")
 
 	if len(errs) != 0 {
 		return fmt.Errorf("group: %s", strings.Join(errs, ", "))
@@ -104,12 +118,42 @@ func (c *container) name() string {
 	return nameOfRunnable(c.runnable)
 }
 
+func (c *container) init(ctx context.Context) error {
+	if r, ok := c.runnable.(RunnableInit); ok {
+		log.Infof("group: init %s", c.name())
+		if err := r.Init(ctx); err != nil {
+			return fmt.Errorf("init %s: %w", c.name(), err)
+		}
+	}
+	return nil
+}
+
 func (c *container) launch(ctx context.Context, completed chan *container, dying chan struct{}) {
 	go func() {
 		c.started = true
-		c.err = c.runnable.Run(ctx)
+		c.err = Recover(c.runnable).Run(ctx)
 		completed <- c
 		dying <- struct{}{}
 		c.stopped = true
 	}()
+}
+
+func (c *container) cleanup(ctx context.Context) {
+	if r, ok := c.runnable.(RunnableCleanup); ok {
+		log.Infof("group: cleanup %s", c.name())
+		err := r.Cleanup(ctx)
+		if err != nil {
+			log.Warnf("group: failed to cleanup %s", c.name())
+		}
+	}
+}
+
+func reverseContainer(containers []*container) []*container {
+	reversed := append([]*container{}, containers...)
+
+	for i, j := 0, len(containers)-1; i < j; i, j = i+1, j-1 {
+		reversed[i], reversed[j] = reversed[j], reversed[i]
+	}
+
+	return reversed
 }

--- a/runnable.go
+++ b/runnable.go
@@ -12,19 +12,21 @@ type Runnable interface {
 	Run(context.Context) error
 }
 
-// // Periodic returns a runnable that will periodically run the runnable passed in argument.
-// func Periodic(period time.Duration, runnable Runnable) Runnable {
-// 	return nil
-// }
+type RunnableInit interface {
+	Runnable
+	Init(context.Context) error
+}
 
-// // Timeout returns a runnable that will periodically run the runnable passed in argument.
-// func Timeout(timeout time.Duration, runnable Runnable) Runnable {
-// 	return nil
-// }
+type RunnableCleanup interface {
+	Runnable
+	Cleanup(context.Context) error
+}
 
-// // RunAndExit runs the runnable and sets the exit code to 1 if the runnable returns an error.
-// func RunAndExit(timeout time.Duration, runnable Runnable) {
-// }
+type RunnableInitCleanup interface {
+	Runnable
+	Init(context.Context) error
+	Cleanup(context.Context) error
+}
 
 func nameOfRunnable(runnable Runnable) string {
 	if r, ok := runnable.(interface{ name() string }); ok {


### PR DESCRIPTION
When a component is both run by Runnable and accessed by other components, it can be accessed before initializing itself.

This PR adds the following interface:

```go
type RunnableInit interface {
	Runnable
	Init(context.Context) error
}

type RunnableCleanup interface {
	Runnable
	Cleanup(context.Context) error
}
```

It also modifies the Group runner to execute the init functions first (in argument order) and the cleanup functions after the runners terminated (in reversed argument order).