### PR TITLE
Ignore wrapped context.Canceled in manager

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -93,7 +93,7 @@ func (m *manager) Run(ctx context.Context) error {
 			m.log("%s is still running", c.name())
 			errs = append(errs, fmt.Sprintf("%s is still running", c.name()))
 		}
-		if c.err != nil && c.err != context.Canceled {
+		if c.err != nil && !errors.Is(c.err, context.Canceled) {
 			errs = append(errs, fmt.Sprintf("%s crashed with %+v", c.name(), c.err))
 		}
 	}


### PR DESCRIPTION
### Context

The manager was still reporting a crash for `context.Canceled`, when it is wrapped:

```
2020/10/22 22:36:53 manager: runnable.httpServer crashed with server shutdown: context canceled
```

### Changes

Fix it