### PR TITLE
HTTPServer: fix the graceful shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Runnable
 
-
 [![GoDoc](https://godoc.org/github.com/pior/runnable?status.svg)](https://pkg.go.dev/github.com/pior/runnable?tab=doc)
 [![Go Report Card](https://goreportcard.com/badge/github.com/pior/runnable)](https://goreportcard.com/report/github.com/pior/runnable)
 
@@ -35,8 +34,31 @@ func run(ctx context.Context) error {
 }
 ```
 
+## HTTP Server
 
-Example of an HTTP server with other in-process services:
+```go
+package main
+
+import (
+	"net/http"
+
+	"github.com/pior/runnable"
+)
+
+func main() {
+	server := &http.Server{
+		Addr:    "127.0.0.1:8000",
+		Handler: http.RedirectHandler("https://go.dev", http.StatusPermanentRedirect),
+	}
+
+	runnable.Run(runnable.HTTPServer(server))
+}
+```
+
+## Manager: run multiple runnables with dependencies
+
+The Manager starts and stops all runnables while respecting dependencies between them.
+Components with dependencies will be stopped before their dependencies.
 
 ```go
 package main

--- a/cmd/http/http.go
+++ b/cmd/http/http.go
@@ -1,15 +1,29 @@
 package main
 
 import (
+	"log"
 	"net/http"
+	"time"
 
 	"github.com/pior/runnable"
 )
 
 func main() {
+	handlerFunc := func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		select {
+		case <-ctx.Done():
+			log.Print("Task interrupted")
+
+		case <-time.After(time.Second * 10):
+			log.Print("Task completed")
+		}
+	}
+
 	server := &http.Server{
-		Addr:    ":80",
-		Handler: http.RedirectHandler("https://golang.org/", http.StatusPermanentRedirect),
+		Addr:    "127.0.0.1:8000",
+		Handler: http.HandlerFunc(handlerFunc),
 	}
 
 	runnable.Run(runnable.HTTPServer(server))


### PR DESCRIPTION
The graceful shutdown of the HTTPServer runnable is not working.

The already cancelled context is passed to the `server.Shutdown()` method.

The shutdown timeout is set to 30s.