### PR TITLE
Simplify runnable naming and add FuncNamed

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Components with dependencies will be stopped before their dependencies.
 
 Example with three components:
 ```go
-g := runnable.Manager(nil)
+g := runnable.NewManager()
 g.Add(jobQueue)
 g.Add(httpServer, jobQueue) // jobs is a dependency
 g.Add(monitor)
@@ -115,20 +115,20 @@ runnable.Run(g.Build())
   <summary markdown="span">Logs of a demo app</summary>
 
 ```shell
-$ go run ./cmd/example
-[RUNNABLE] 2020/10/22 22:42:26 INFO manager: main.JobQueue started
-[RUNNABLE] 2020/10/22 22:42:26 INFO manager: runnable.httpServer started
-[RUNNABLE] 2020/10/22 22:42:26 INFO manager: main.Monitor started
+$ go run ./examples/example
+level=INFO msg=started runnable=manager/JobQueue
+level=INFO msg=started runnable=manager/httpserver
+level=INFO msg=started runnable=manager/Monitor
 ...
-^C[RUNNABLE] 2020/10/22 22:42:34 INFO signal: received signal interrupt
-[RUNNABLE] 2020/10/22 22:42:34 INFO manager: starting shutdown (context cancelled)
-[RUNNABLE] 2020/10/22 22:42:34 INFO manager: runnable.httpServer cancelled
-[RUNNABLE] 2020/10/22 22:42:34 INFO manager: main.Monitor cancelled
-[RUNNABLE] 2020/10/22 22:42:34 INFO manager: main.Monitor stopped
-[RUNNABLE] 2020/10/22 22:42:34 INFO manager: runnable.httpServer stopped
-[RUNNABLE] 2020/10/22 22:42:34 INFO manager: main.JobQueue cancelled
-[RUNNABLE] 2020/10/22 22:42:34 INFO manager: main.JobQueue stopped
-[RUNNABLE] 2020/10/22 22:42:34 INFO manager: shutdown complete
+^Clevel=INFO msg="received signal" runnable=signal/manager signal=interrupt
+level=INFO msg="starting shutdown" runnable=manager reason="context cancelled"
+level=INFO msg=cancelled runnable=manager/httpserver
+level=INFO msg=cancelled runnable=manager/Monitor
+level=INFO msg=stopped runnable=manager/Monitor
+level=INFO msg=stopped runnable=manager/httpserver
+level=INFO msg=cancelled runnable=manager/JobQueue
+level=INFO msg=stopped runnable=manager/JobQueue
+level=INFO msg="shutdown complete" runnable=manager
 ```
 
 </details>

--- a/closer.go
+++ b/closer.go
@@ -6,39 +6,40 @@ import (
 
 // Closer returns a runnable intended to call a Close method on shutdown.
 func Closer(c interface{ Close() }) Runnable {
-	return &closer{baseWrapper{"closer", c}, c, func(ctx context.Context) error {
+	return &closer{"closer/" + runnableName(c), func(ctx context.Context) error {
 		c.Close()
 		return nil
 	}}
 }
 
-// Closer returns a runnable intended to call a Close method on shutdown.
+// CloserErr returns a runnable intended to call a Close method on shutdown.
 func CloserErr(c interface{ Close() error }) Runnable {
-	return &closer{baseWrapper{"closer", c}, c, func(ctx context.Context) error {
+	return &closer{"closer/" + runnableName(c), func(ctx context.Context) error {
 		return c.Close()
 	}}
 }
 
-// Closer returns a runnable intended to call a Close method on shutdown.
+// CloserCtx returns a runnable intended to call a Close method on shutdown.
 func CloserCtx(c interface{ Close(context.Context) }) Runnable {
-	return &closer{baseWrapper{"closer", c}, c, func(ctx context.Context) error {
+	return &closer{"closer/" + runnableName(c), func(ctx context.Context) error {
 		c.Close(ctx)
 		return nil
 	}}
 }
 
-// Closer returns a runnable intended to call a Close method on shutdown.
+// CloserCtxErr returns a runnable intended to call a Close method on shutdown.
 func CloserCtxErr(c interface{ Close(context.Context) error }) Runnable {
-	return &closer{baseWrapper{"closer", c}, c, func(ctx context.Context) error {
+	return &closer{"closer/" + runnableName(c), func(ctx context.Context) error {
 		return c.Close(ctx)
 	}}
 }
 
 type closer struct {
-	baseWrapper
-	c       any
+	name    string
 	closeFn func(context.Context) error
 }
+
+func (c *closer) runnableName() string { return c.name }
 
 func (c *closer) Run(ctx context.Context) error {
 	<-ctx.Done()

--- a/every.go
+++ b/every.go
@@ -8,17 +8,19 @@ import (
 // Every returns a runnable that will periodically run the runnable passed in argument.
 func Every(runnable Runnable, period time.Duration) Runnable {
 	return &every{
-		baseWrapper{"every-" + period.String(), runnable},
-		runnable,
-		period,
+		name:     "every-" + period.String() + "/" + runnableName(runnable),
+		runnable: runnable,
+		period:   period,
 	}
 }
 
 type every struct {
-	baseWrapper
+	name     string
 	runnable Runnable
 	period   time.Duration
 }
+
+func (e *every) runnableName() string { return e.name }
 
 func (e *every) Run(ctx context.Context) (err error) {
 	ticker := time.NewTicker(e.period)

--- a/example_test.go
+++ b/example_test.go
@@ -65,7 +65,7 @@ func Example() {
 	}
 	g.Add(runnable.HTTPServer(server), jobs)
 
-	task := runnable.Func(func(ctx context.Context) error {
+	task := runnable.FuncNamed("enqueue", func(ctx context.Context) error {
 		_, _ = http.Post("http://127.0.0.1:8080/?id=1", "test/plain", nil)
 		_, _ = http.Post("http://127.0.0.1:8080/?id=2", "test/plain", nil)
 		_, _ = http.Post("http://127.0.0.1:8080/?id=3", "test/plain", nil)
@@ -81,12 +81,12 @@ func Example() {
 
 	// level=INFO msg=started runnable=manager/Jobs
 	// level=INFO msg=started runnable=manager/httpserver
-	// level=INFO msg=started runnable=manager/RunnableFunc
+	// level=INFO msg=started runnable=manager/enqueue
 	// level=INFO msg=started runnable=manager/every-1h0m0s/CleanupTask
 	// level=INFO msg=listening runnable=httpserver addr=127.0.0.1:8080
 	// Starting job 1
 	// Completed job 1
 	// ...
-	// level=INFO msg="starting shutdown" runnable=manager reason="RunnableFunc died"
+	// level=INFO msg="starting shutdown" runnable=manager reason="enqueue died"
 	// level=INFO msg="shutdown complete" runnable=manager
 }

--- a/func.go
+++ b/func.go
@@ -1,16 +1,30 @@
 package runnable
 
-import "context"
+import (
+	"context"
+	"reflect"
+	"runtime"
+)
 
+// RunnableFunc is a function that implements the Runnable contract.
 type RunnableFunc func(context.Context) error
 
 type funcRunnable struct {
-	baseWrapper
-	fn RunnableFunc
+	name string
+	fn   RunnableFunc
 }
 
+func (f *funcRunnable) runnableName() string { return f.name }
+
+// Func returns a Runnable from a function. The name is derived from the function using reflection.
 func Func(fn RunnableFunc) Runnable {
-	return &funcRunnable{baseWrapper{"", fn}, fn}
+	name := runtime.FuncForPC(reflect.ValueOf(fn).Pointer()).Name()
+	return &funcRunnable{name, fn}
+}
+
+// FuncNamed returns a named Runnable from a function.
+func FuncNamed(name string, fn RunnableFunc) Runnable {
+	return &funcRunnable{name, fn}
 }
 
 func (f *funcRunnable) Run(ctx context.Context) error {

--- a/manager_container.go
+++ b/manager_container.go
@@ -32,7 +32,7 @@ func (c *managerContainer) insertUser(container *managerContainer) {
 }
 
 func (c *managerContainer) name() string {
-	return findName(c.runnable)
+	return runnableName(c.runnable)
 }
 
 func (c *managerContainer) launch(completed chan *managerContainer, dying chan *managerContainer) {

--- a/recover.go
+++ b/recover.go
@@ -22,15 +22,17 @@ func (e *PanicError) Unwrap() error {
 
 // Recover returns a runnable that recovers when a runnable panics and return an error to represent this panic.
 func Recover(runnable Runnable) Runnable {
-	return &RecoverRunner{baseWrapper{"recover", runnable}, runnable}
+	return &recoverRunner{"recover/" + runnableName(runnable), runnable}
 }
 
-type RecoverRunner struct {
-	baseWrapper
+type recoverRunner struct {
+	name     string
 	runnable Runnable
 }
 
-func (r *RecoverRunner) Run(ctx context.Context) (err error) {
+func (r *recoverRunner) runnableName() string { return r.name }
+
+func (r *recoverRunner) Run(ctx context.Context) (err error) {
 	defer func() {
 		if value := recover(); value != nil {
 			err = &PanicError{value}

--- a/runnable_test.go
+++ b/runnable_test.go
@@ -7,32 +7,40 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_findName(t *testing.T) {
-	require.Equal(t, "github.com/pior/runnable.Test_findName.func1()",
-		findName(Func(func(ctx context.Context) error { return nil })),
+func Test_runnableName(t *testing.T) {
+	require.Equal(t, "github.com/pior/runnable.Test_runnableName.func1",
+		runnableName(Func(func(ctx context.Context) error { return nil })),
 	)
 
-	require.Equal(t, "github.com/pior/runnable.funcTesting()",
-		findName(Func(funcTesting)),
+	require.Equal(t, "github.com/pior/runnable.funcTesting",
+		runnableName(Func(funcTesting)),
+	)
+
+	require.Equal(t, "custom-name",
+		runnableName(FuncNamed("custom-name", funcTesting)),
 	)
 
 	require.Equal(t, "dummyRunnable",
-		findName(newDummyRunnable()),
+		runnableName(newDummyRunnable()),
 	)
 
 	require.Equal(t, "restart/dummyRunnable",
-		findName(Restart(newDummyRunnable())),
+		runnableName(Restart(newDummyRunnable())),
 	)
 
 	require.Equal(t, "every-0s/dummyRunnable",
-		findName(Every(newDummyRunnable(), 0)),
+		runnableName(Every(newDummyRunnable(), 0)),
 	)
 
 	require.Equal(t, "recover/dummyRunnable",
-		findName(Recover(newDummyRunnable())),
+		runnableName(Recover(newDummyRunnable())),
+	)
+
+	require.Equal(t, "restart/closer/dummyCloser",
+		runnableName(Restart(CloserErr(&dummyCloser{}))),
 	)
 
 	require.Equal(t, "restart/recover/closer/dummyCloser",
-		findName(Restart(Recover(CloserErr(&dummyCloser{})))),
+		runnableName(Restart(Recover(CloserErr(&dummyCloser{})))),
 	)
 }

--- a/testing_test.go
+++ b/testing_test.go
@@ -20,9 +20,9 @@ func newDummyRunnable() *dummyRunnable {
 type dummyRunnable struct{}
 
 func (r *dummyRunnable) Run(ctx context.Context) error {
-	logger.Info("started", "runnable", findName(r))
+	logger.Info("started", "runnable", runnableName(r))
 	<-ctx.Done()
-	logger.Info("stopped", "runnable", findName(r))
+	logger.Info("stopped", "runnable", runnableName(r))
 	return ctx.Err()
 }
 


### PR DESCRIPTION

  - **Simplify naming**: Remove `findName` chain-walking, `baseWrapper` struct,
    and `RunnableName`/`RunnableUnwrap` implicit interfaces. Wrappers now
    compose a name string at construction time using a single unexported
    `runnableName()` helper with reflection fallback.
  - **Add `FuncNamed(name, fn)`**: Lets users name function runnables explicitly,
    solving the problem of multiple `Func()` instances being indistinguishable
    in logs.
  - **Add `ManagerName` option**: Customize the manager's name in logs
    (defaults to "manager").
  - **Func() uses `runtime.FuncForPC`**: Auto-detects meaningful function names
    instead of showing the generic type name.
  - **Update README**: Fix stale `Manager(nil)` → `NewManager()`, update log
    output examples to slog format.
