### PR TITLE
Fix shutdown issue and logging in HTTPServer

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,14 @@ A `Manager` is itself a `Runnable`, so managers can be nested for independent sh
 $ go run ./examples/example/
 level=INFO msg=started runnable=manager/StupidJobQueue
 level=INFO msg=started runnable=manager/httpserver
-level=INFO msg=started runnable=manager/every-3s/RunnableFunc
+level=INFO msg=listening runnable=httpserver addr=localhost:8000
 ...
 ^C
-level=INFO msg="signal received" runnable=signal signal=interrupt
+level=INFO msg="received signal" runnable=signal/manager signal=interrupt
 level=INFO msg="starting shutdown" runnable=manager reason="context cancelled"
+level=INFO msg="shutting down" runnable=httpserver
+level=INFO msg=stopped runnable=httpserver
 level=INFO msg=stopped runnable=manager/httpserver
-level=INFO msg=stopped runnable=manager/every-3s/RunnableFunc
 level=INFO msg=stopped runnable=manager/StupidJobQueue
 level=INFO msg="shutdown complete" runnable=manager
 ```

--- a/server_test.go
+++ b/server_test.go
@@ -1,8 +1,112 @@
 package runnable
 
 import (
+	"context"
+	"fmt"
+	"net"
 	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
 )
+
+func TestHTTPServer(t *testing.T) {
+	t.Run("graceful shutdown", func(t *testing.T) {
+		server := &http.Server{
+			Addr:    "127.0.0.1:0",
+			Handler: http.NotFoundHandler(),
+		}
+
+		// Use a real listener to get an available port.
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		server.Addr = ln.Addr().String()
+		_ = ln.Close()
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		errChan := make(chan error, 1)
+		go func() {
+			errChan <- HTTPServer(server).Run(ctx)
+		}()
+
+		// Wait for the server to be accepting connections.
+		require.Eventually(t, func() bool {
+			conn, dialErr := net.Dial("tcp", server.Addr)
+			if dialErr != nil {
+				return false
+			}
+			_ = conn.Close()
+			return true
+		}, time.Second, 10*time.Millisecond)
+
+		cancel()
+
+		select {
+		case err := <-errChan:
+			require.NoError(t, err)
+		case <-time.After(5 * time.Second):
+			t.Fatal("server did not shut down within 5s")
+		}
+	})
+
+	t.Run("listen error", func(t *testing.T) {
+		server := &http.Server{
+			Addr:    "INVALID",
+			Handler: http.NotFoundHandler(),
+		}
+
+		err := HTTPServer(server).Run(context.Background())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "missing port in address")
+	})
+
+	t.Run("pre-cancelled context", func(t *testing.T) {
+		server := &http.Server{
+			Addr:    "127.0.0.1:0",
+			Handler: http.NotFoundHandler(),
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		errChan := make(chan error, 1)
+		go func() {
+			errChan <- HTTPServer(server).Run(ctx)
+		}()
+
+		select {
+		case err := <-errChan:
+			require.NoError(t, err)
+		case <-time.After(5 * time.Second):
+			t.Fatal("server did not return within 5s")
+		}
+	})
+
+	t.Run("name is configurable", func(t *testing.T) {
+		server := &http.Server{
+			Addr:    "127.0.0.1:0",
+			Handler: http.NotFoundHandler(),
+		}
+
+		r := HTTPServer(server).Name("api")
+
+		require.Equal(t, "api", r.runnableName())
+	})
+
+	t.Run("shutdown timeout is configurable", func(t *testing.T) {
+		server := &http.Server{
+			Addr:    "127.0.0.1:0",
+			Handler: http.NotFoundHandler(),
+		}
+
+		r := HTTPServer(server).ShutdownTimeout(5 * time.Second)
+
+		require.Equal(t, fmt.Sprint(5*time.Second), fmt.Sprint(r.shutdownTimeout))
+	})
+
+}
 
 func ExampleHTTPServer() {
 	ctx, cancel := initializeForExample()
@@ -19,7 +123,8 @@ func ExampleHTTPServer() {
 
 	// Output:
 	// level=INFO msg=listening runnable=httpserver addr=127.0.0.1:8080
-	// level=INFO msg=shutdown runnable=httpserver
+	// level=INFO msg="shutting down" runnable=httpserver
+	// level=INFO msg=stopped runnable=httpserver
 }
 
 func ExampleHTTPServer_error() {
@@ -37,5 +142,5 @@ func ExampleHTTPServer_error() {
 
 	// Output:
 	// level=INFO msg=listening runnable=httpserver addr=INVALID
-	// level=INFO msg=shutdown runnable=httpserver error="listen tcp: address INVALID: missing port in address"
+	// level=INFO msg="stopped with error" runnable=httpserver error="listen tcp: address INVALID: missing port in address"
 }


### PR DESCRIPTION

- **Configurable shutdown timeout** — `HTTPServer` now returns `*httpServer` (still satisfies `Runnable`) with a fluent API: `.Name(string)` and `.ShutdownTimeout(time.Duration)`. The shutdown timeout was previously hardcoded at 30s.
- **Fix unnecessary Shutdown call** — When `ListenAndServe` fails on its own (e.g. port in use), the code no longer calls `Shutdown` on an already-dead server.
- **Clearer log messages** — Graceful shutdown now logs `"shutting down"` → `"stopped"` (matching the manager's pattern). Server errors log `"stopped with error"` instead of the ambiguous `"shutdown"`.
- **Real unit tests** — Added tests for graceful shutdown, listen error, pre-cancelled context, and fluent API configuration. Kept existing example tests.
- **Updated README** example logs to match actual output.
