### PR TITLE
Rewrite Restart wrapper: fluent API, consecutive error counting, panic recovery

### DIFF
--- a/examples/crashing/main.go
+++ b/examples/crashing/main.go
@@ -17,5 +17,5 @@ func (s *crashing) Run(ctx context.Context) error {
 }
 
 func main() {
-	runnable.Run(runnable.Restart(&crashing{}, runnable.RestartCrashLimit(5)))
+	runnable.Run(runnable.Restart(&crashing{}).ErrorLimit(5))
 }

--- a/restart.go
+++ b/restart.go
@@ -5,91 +5,120 @@ import (
 	"time"
 )
 
-type restartConfig struct {
-	restartLimit        int
-	crashLimit          int
-	restartDelay        time.Duration
-	crashBackoffDelayFn func(int) time.Duration
-}
-
-type RestartOption func(*restartConfig)
-
-// RestartLimit sets a limit on the number of restart after successful execution.
-func RestartLimit(times int) RestartOption {
-	return func(cfg *restartConfig) {
-		cfg.restartLimit = times
+// Restart returns a runnable that keeps running the given runnable, restarting it
+// after both successful exits and errors. Panics are recovered and treated as errors.
+//
+// On successful exit, the runnable is restarted after [restart.Delay] (default: immediate).
+// On error, the runnable is restarted after a backoff period determined by
+// [restart.ErrorBackoff] (default: immediate for ≤3 errors, 10s for ≤10, then 1m).
+//
+// The error count tracks consecutive errors and resets to zero after any successful
+// run. Use [restart.ErrorResetAfter] to also reset after a run that lasted long
+// enough before failing.
+//
+// Restart loops indefinitely unless limited by [restart.Limit] or [restart.ErrorLimit].
+// When the restart limit is reached, Restart returns nil. When the error limit is
+// reached, Restart returns the last error.
+// Context cancellation stops the loop and returns [context.Canceled].
+func Restart(runnable Runnable) *restart {
+	return &restart{
+		name:           "restart/" + runnableName(runnable),
+		runnable:       Recover(runnable),
+		errorBackoffFn: defaultErrorBackoff,
 	}
-}
-
-// RestartCrashLimit sets a limit on the number restart after a crash.
-func RestartCrashLimit(times int) RestartOption {
-	return func(cfg *restartConfig) {
-		cfg.crashLimit = times
-	}
-}
-
-// RestartDelay sets the time waited before restarting the runnable after a successful execution.
-func RestartDelay(delay time.Duration) RestartOption {
-	return func(cfg *restartConfig) {
-		cfg.restartDelay = delay
-	}
-}
-
-// RestartCrashDelayFn sets the function that determine the backoff delay after a crash.
-func RestartCrashDelayFn(fn func(int) time.Duration) RestartOption {
-	return func(cfg *restartConfig) {
-		cfg.crashBackoffDelayFn = fn
-	}
-}
-
-// Restart returns a runnable that runs a runnable and restarts it when it fails, with some conditions.
-func Restart(runnable Runnable, opts ...RestartOption) Runnable {
-	cfg := restartConfig{}
-	for _, opt := range opts {
-		opt(&cfg)
-	}
-	if cfg.crashBackoffDelayFn == nil {
-		cfg.crashBackoffDelayFn = crashBackoffDelay
-	}
-	return &restart{"restart/" + runnableName(runnable), runnable, cfg}
 }
 
 type restart struct {
-	name     string
-	runnable Runnable
-	cfg      restartConfig
+	name            string
+	runnable        Runnable
+	limit           int
+	errorLimit      int
+	delay           time.Duration
+	errorBackoffFn  func(int) time.Duration
+	errorResetAfter time.Duration
 }
+
+var _ Runnable = (*restart)(nil)
 
 func (r *restart) runnableName() string { return r.name }
 
+// Limit sets the maximum number of restarts after successful (nil) exits.
+// When reached, returns nil. Zero means unlimited (the default).
+func (r *restart) Limit(n int) *restart {
+	r.limit = n
+	return r
+}
+
+// ErrorLimit sets the maximum number of consecutive restarts after errors.
+// When reached, returns the last error. Zero means unlimited (the default).
+func (r *restart) ErrorLimit(n int) *restart {
+	r.errorLimit = n
+	return r
+}
+
+// Delay sets the time to wait before restarting after a successful exit.
+// Defaults to zero (immediate restart).
+func (r *restart) Delay(d time.Duration) *restart {
+	r.delay = d
+	return r
+}
+
+// ErrorBackoff sets the function that determines the delay before restarting
+// after an error. It receives the current consecutive error count (starting at 1).
+// The default backs off: immediate for the first 3 errors, 10s up to 10, then 1m.
+func (r *restart) ErrorBackoff(fn func(errors int) time.Duration) *restart {
+	r.errorBackoffFn = fn
+	return r
+}
+
+// ErrorResetAfter resets the consecutive error count when a single run lasted
+// at least the given duration before failing. This prevents long-running services
+// that occasionally fail from accumulating stale error counts into the backoff.
+// Zero means never reset based on duration (the default). Successful runs always
+// reset the error count regardless of this setting.
+func (r *restart) ErrorResetAfter(d time.Duration) *restart {
+	r.errorResetAfter = d
+	return r
+}
+
 func (r *restart) Run(ctx context.Context) error {
 	restartCount := 0
-	crashCount := 0
+	errorCount := 0
 
 	for {
-		logger.Info("starting", "runnable", r.name, "restart", restartCount, "crash", crashCount)
+		logger.Info("starting", "runnable", r.name, "restart", restartCount, "errors", errorCount)
+
+		startTime := time.Now()
 		err := r.runnable.Run(ctx)
-		isCrash := err != nil
 
-		if isCrash {
-			crashCount++
+		if ctx.Err() != nil {
+			return ctx.Err()
 		}
 
-		if r.cfg.restartLimit > 0 && restartCount >= r.cfg.restartLimit {
-			logger.Info("not restarting", "runnable", r.name, "reason", "restart limit", "limit", r.cfg.restartLimit)
-			return err
-		}
+		if err != nil {
+			if r.errorResetAfter > 0 && time.Since(startTime) >= r.errorResetAfter {
+				errorCount = 0
+			}
+			errorCount++
 
-		if r.cfg.crashLimit > 0 && crashCount >= r.cfg.crashLimit {
-			logger.Info("not restarting", "runnable", r.name, "reason", "crash limit", "limit", r.cfg.crashLimit)
-			return err
+			if r.errorLimit > 0 && errorCount >= r.errorLimit {
+				logger.Info("not restarting", "runnable", r.name, "reason", "error limit", "limit", r.errorLimit)
+				return err
+			}
+		} else {
+			errorCount = 0
+
+			if r.limit > 0 && restartCount >= r.limit {
+				logger.Info("not restarting", "runnable", r.name, "reason", "restart limit", "limit", r.limit)
+				return nil
+			}
 		}
 
 		restartCount++
 
-		delay := r.cfg.restartDelay
-		if isCrash {
-			delay = r.cfg.crashBackoffDelayFn(crashCount)
+		delay := r.delay
+		if err != nil {
+			delay = r.errorBackoffFn(errorCount)
 		}
 
 		select {
@@ -100,12 +129,13 @@ func (r *restart) Run(ctx context.Context) error {
 	}
 }
 
-func crashBackoffDelay(crashCount int) time.Duration {
-	if crashCount <= 3 {
+func defaultErrorBackoff(errorCount int) time.Duration {
+	switch {
+	case errorCount <= 3:
 		return 0
-	} else if crashCount <= 10 {
-		return time.Second * 10
-	} else {
+	case errorCount <= 10:
+		return 10 * time.Second
+	default:
 		return time.Minute
 	}
 }

--- a/restart_test.go
+++ b/restart_test.go
@@ -2,50 +2,197 @@ package runnable
 
 import (
 	"context"
+	"errors"
+	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/require"
 )
 
+func TestRestart(t *testing.T) {
+	t.Run("cancellation", func(t *testing.T) {
+		r := Restart(newDummyRunnable())
+		AssertRunnableRespectCancellation(t, r, time.Millisecond*100)
+		AssertRunnableRespectPreCancelledContext(t, r)
+	})
+
+	t.Run("restart limit", func(t *testing.T) {
+		counter := newCounterRunnable()
+
+		r := Restart(counter).Limit(10)
+		err := r.Run(context.Background())
+		require.NoError(t, err)
+
+		require.Equal(t, 11, counter.counter) // 10 restarts = 11 executions
+	})
+
+	t.Run("error limit", func(t *testing.T) {
+		counter := newDyingRunnable()
+
+		r := Restart(counter).
+			ErrorLimit(10).
+			ErrorBackoff(func(int) time.Duration { return 0 })
+		err := r.Run(context.Background())
+		require.EqualError(t, err, "dying")
+
+		require.Equal(t, 10, counter.counter)
+	})
+
+	t.Run("error count resets on success", func(t *testing.T) {
+		// Alternates: error, success, error, success, ...
+		// Error count should never exceed 1, so ErrorLimit(2) is never reached.
+		callCount := 0
+		fn := Func(func(ctx context.Context) error {
+			callCount++
+			if callCount%2 == 1 {
+				return errors.New("odd")
+			}
+			return nil
+		})
+
+		r := Restart(fn).
+			ErrorLimit(2).
+			Limit(3).
+			ErrorBackoff(func(int) time.Duration { return 0 })
+		err := r.Run(context.Background())
+		require.NoError(t, err) // hit restart limit, not error limit
+
+		// Sequence: run1=err(errorCount=1, restartCount→1),
+		//           run2=ok(errorCount→0, restartCount=1<3, restartCount→2),
+		//           run3=err(errorCount=1, restartCount→3),
+		//           run4=ok(errorCount→0, restartCount=3>=3 → stop)
+		require.Equal(t, 4, callCount)
+	})
+
+	t.Run("panic recovery", func(t *testing.T) {
+		callCount := 0
+		fn := Func(func(ctx context.Context) error {
+			callCount++
+			panic("boom")
+		})
+
+		r := Restart(fn).ErrorLimit(3).
+			ErrorBackoff(func(int) time.Duration { return 0 })
+		err := r.Run(context.Background())
+
+		require.Equal(t, 3, callCount)
+		var panicErr *PanicError
+		require.ErrorAs(t, err, &panicErr)
+		require.Equal(t, "runnable panicked: boom", err.Error())
+	})
+
+	t.Run("error backoff", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			var count atomic.Int32
+			fn := Func(func(ctx context.Context) error {
+				count.Add(1)
+				return errors.New("fail")
+			})
+
+			ctx, cancel := context.WithCancel(context.Background())
+
+			r := Restart(fn).ErrorBackoff(func(n int) time.Duration {
+				return 10 * time.Second
+			})
+
+			errChan := make(chan error, 1)
+			go func() {
+				errChan <- r.Run(ctx)
+			}()
+
+			// First run is immediate. Then 10s backoff before each retry.
+			time.Sleep(1 * time.Nanosecond) // let first run complete
+			require.Equal(t, int32(1), count.Load())
+
+			time.Sleep(10*time.Second + 1)
+			require.Equal(t, int32(2), count.Load())
+
+			time.Sleep(10*time.Second + 1)
+			require.Equal(t, int32(3), count.Load())
+
+			cancel()
+			err := <-errChan
+			require.EqualError(t, err, "context canceled")
+		})
+	})
+
+	t.Run("error reset after stable run", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			var runCount atomic.Int32
+			fn := Func(func(ctx context.Context) error {
+				// Simulate a service that runs for a while then fails.
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-time.After(time.Hour):
+					runCount.Add(1)
+					return errors.New("fail")
+				}
+			})
+
+			ctx, cancel := context.WithCancel(context.Background())
+
+			backoffCalls := []int{}
+			r := Restart(fn).
+				ErrorResetAfter(30 * time.Minute).
+				ErrorBackoff(func(n int) time.Duration {
+					backoffCalls = append(backoffCalls, n)
+					return 0
+				})
+
+			errChan := make(chan error, 1)
+			go func() {
+				errChan <- r.Run(ctx)
+			}()
+
+			// First run: runs for 1h (≥30m reset threshold), then errors.
+			// Error count resets before incrementing → errorCount=1.
+			time.Sleep(time.Hour + 1*time.Nanosecond)
+			require.Equal(t, int32(1), runCount.Load())
+
+			// Second run: same pattern. Error count resets again → errorCount=1.
+			time.Sleep(time.Hour + 1*time.Nanosecond)
+			require.Equal(t, int32(2), runCount.Load())
+
+			cancel()
+			<-errChan
+
+			// Both backoff calls received errorCount=1 because each run
+			// lasted ≥ ErrorResetAfter, resetting the count before incrementing.
+			// Without ErrorResetAfter, the second call would have received 2.
+			require.Equal(t, []int{1, 1}, backoffCalls)
+		})
+	})
+}
+
 func ExampleRestart() {
 	ctx, cancel := initializeForExample()
 	defer cancel()
 
-	runnable := newDyingRunnable()
-
-	r := Restart(runnable, RestartCrashLimit(3))
+	worker := newDyingRunnable()
+	r := Restart(worker).ErrorLimit(3)
 	_ = r.Run(ctx)
 
 	// Output:
-	// level=INFO msg=starting runnable=restart/dyingRunnable restart=0 crash=0
-	// level=INFO msg=starting runnable=restart/dyingRunnable restart=1 crash=1
-	// level=INFO msg=starting runnable=restart/dyingRunnable restart=2 crash=2
-	// level=INFO msg="not restarting" runnable=restart/dyingRunnable reason="crash limit" limit=3
+	// level=INFO msg=starting runnable=restart/dyingRunnable restart=0 errors=0
+	// level=INFO msg=starting runnable=restart/dyingRunnable restart=1 errors=1
+	// level=INFO msg=starting runnable=restart/dyingRunnable restart=2 errors=2
+	// level=INFO msg="not restarting" runnable=restart/dyingRunnable reason="error limit" limit=3
 }
 
-func TestRestart_Cancellation(t *testing.T) {
-	r := Restart(newDummyRunnable())
-	AssertRunnableRespectCancellation(t, r, time.Millisecond*100)
-	AssertRunnableRespectPreCancelledContext(t, r)
-}
+func ExampleRestart_worker() {
+	ctx, cancel := initializeForExample()
+	defer cancel()
 
-func TestRestart_Restart(t *testing.T) {
-	counter := newCounterRunnable()
+	worker := newCounterRunnable()
+	r := Restart(worker).Limit(2).Delay(time.Millisecond)
+	_ = r.Run(ctx)
 
-	r := Restart(counter, RestartLimit(10))
-	err := r.Run(context.Background())
-	require.NoError(t, err)
-
-	require.Equal(t, 11, counter.counter) // 10 restarts is 11 executions
-}
-
-func TestRestart_Crash_Restart(t *testing.T) {
-	counter := newDyingRunnable()
-
-	r := Restart(counter, RestartCrashLimit(10), RestartCrashDelayFn(func(int) time.Duration { return 0 }))
-	err := r.Run(context.Background())
-	require.EqualError(t, err, "dying")
-
-	require.Equal(t, 10, counter.counter)
+	// Output:
+	// level=INFO msg=starting runnable=restart/counter restart=0 errors=0
+	// level=INFO msg=starting runnable=restart/counter restart=1 errors=0
+	// level=INFO msg=starting runnable=restart/counter restart=2 errors=0
+	// level=INFO msg="not restarting" runnable=restart/counter reason="restart limit" limit=2
 }


### PR DESCRIPTION

- **Fluent API** — `Restart` now returns `*restart` with chainable methods (`.Limit()`, `.ErrorLimit()`, `.Delay()`, `.ErrorBackoff()`, `.ErrorResetAfter()`), replacing the functional options pattern (`RestartOption`, `RestartLimit`, `RestartCrashLimit`, etc.). This aligns with the other configurable wrappers (Manager, HTTPServer).
- **Rename crash → error** — "crash" was misleading in Go (returning an error isn't crashing). All terminology now uses "error": `ErrorLimit`, `ErrorBackoff`, `ErrorResetAfter`, and log fields say `errors=N` instead of `crash=N`.
- **Consecutive error counting** — `errorCount` now resets to 0 after any successful run. Previously `crashCount` accumulated across successes (total budget). `ErrorLimit` means "max consecutive errors", which is more useful operationally.
- **ErrorResetAfter** — New feature: resets the error count when a run lasted long enough before failing. Prevents long-running services that occasionally fail from accumulating stale error counts into the backoff.
- **Built-in panic recovery** — Restart now wraps the inner runnable with `Recover()`, matching how Manager handles panics. No need to explicitly write `Restart(Recover(worker))`.
- **Early context cancellation check** — The restart loop checks `ctx.Err()` immediately after each run, stopping without counting errors or calling backoff.