### PR TITLE
Consistent logging with name prefix in message

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -79,14 +79,14 @@ func Example() {
 
 	runnable.Run(g)
 
-	// level=INFO msg=started runnable=manager/Jobs
-	// level=INFO msg=started runnable=manager/httpserver
-	// level=INFO msg=started runnable=manager/enqueue
-	// level=INFO msg=started runnable=manager/schedule/CleanupTask
-	// level=INFO msg=listening runnable=httpserver addr=127.0.0.1:8080
+	// level=INFO msg="manager/Jobs: started"
+	// level=INFO msg="manager/httpserver: started"
+	// level=INFO msg="manager/enqueue: started"
+	// level=INFO msg="manager/schedule/CleanupTask: started"
+	// level=INFO msg="httpserver: listening" addr=127.0.0.1:8080
 	// Starting job 1
 	// Completed job 1
 	// ...
-	// level=INFO msg="starting shutdown" runnable=manager reason="enqueue died"
-	// level=INFO msg="shutdown complete" runnable=manager
+	// level=INFO msg="manager: starting shutdown" reason="enqueue died"
+	// level=INFO msg="manager: shutdown complete"
 }

--- a/restart.go
+++ b/restart.go
@@ -86,7 +86,7 @@ func (r *restart) Run(ctx context.Context) error {
 	errorCount := 0
 
 	for {
-		logger.Info("starting", "runnable", r.name, "restart", restartCount, "errors", errorCount)
+		logger.Info(r.name+": starting", "restart", restartCount, "errors", errorCount)
 
 		startTime := time.Now()
 		err := r.runnable.Run(ctx)
@@ -102,14 +102,14 @@ func (r *restart) Run(ctx context.Context) error {
 			errorCount++
 
 			if r.errorLimit > 0 && errorCount >= r.errorLimit {
-				logger.Info("not restarting", "runnable", r.name, "reason", "error limit", "limit", r.errorLimit)
+				logger.Info(r.name+": not restarting", "reason", "error limit", "limit", r.errorLimit)
 				return err
 			}
 		} else {
 			errorCount = 0
 
 			if r.limit > 0 && restartCount >= r.limit {
-				logger.Info("not restarting", "runnable", r.name, "reason", "restart limit", "limit", r.limit)
+				logger.Info(r.name+": not restarting", "reason", "restart limit", "limit", r.limit)
 				return nil
 			}
 		}

--- a/restart_test.go
+++ b/restart_test.go
@@ -176,10 +176,10 @@ func ExampleRestart() {
 	_ = r.Run(ctx)
 
 	// Output:
-	// level=INFO msg=starting runnable=restart/dyingRunnable restart=0 errors=0
-	// level=INFO msg=starting runnable=restart/dyingRunnable restart=1 errors=1
-	// level=INFO msg=starting runnable=restart/dyingRunnable restart=2 errors=2
-	// level=INFO msg="not restarting" runnable=restart/dyingRunnable reason="error limit" limit=3
+	// level=INFO msg="restart/dyingRunnable: starting" restart=0 errors=0
+	// level=INFO msg="restart/dyingRunnable: starting" restart=1 errors=1
+	// level=INFO msg="restart/dyingRunnable: starting" restart=2 errors=2
+	// level=INFO msg="restart/dyingRunnable: not restarting" reason="error limit" limit=3
 }
 
 func ExampleRestart_worker() {
@@ -191,8 +191,8 @@ func ExampleRestart_worker() {
 	_ = r.Run(ctx)
 
 	// Output:
-	// level=INFO msg=starting runnable=restart/counter restart=0 errors=0
-	// level=INFO msg=starting runnable=restart/counter restart=1 errors=0
-	// level=INFO msg=starting runnable=restart/counter restart=2 errors=0
-	// level=INFO msg="not restarting" runnable=restart/counter reason="restart limit" limit=2
+	// level=INFO msg="restart/counter: starting" restart=0 errors=0
+	// level=INFO msg="restart/counter: starting" restart=1 errors=0
+	// level=INFO msg="restart/counter: starting" restart=2 errors=0
+	// level=INFO msg="restart/counter: not restarting" reason="restart limit" limit=2
 }

--- a/server.go
+++ b/server.go
@@ -47,7 +47,7 @@ func (r *httpServer) Run(ctx context.Context) error {
 	errChan := make(chan error)
 
 	go func() {
-		logger.Info("listening", "runnable", r.name, "addr", r.server.Addr)
+		logger.Info(r.name+": listening", "addr", r.server.Addr)
 		errChan <- r.server.ListenAndServe()
 	}()
 
@@ -56,12 +56,12 @@ func (r *httpServer) Run(ctx context.Context) error {
 
 	select {
 	case <-ctx.Done():
-		logger.Info("shutting down", "runnable", r.name)
+		logger.Info(r.name + ": shutting down")
 		shutdownErr = r.shutdown()
 		err = <-errChan
-		logger.Info("stopped", "runnable", r.name)
+		logger.Info(r.name + ": stopped")
 	case err = <-errChan:
-		logger.Info("stopped with error", "runnable", r.name, "error", err)
+		logger.Info(r.name+": stopped with error", "error", err)
 		// Server stopped on its own — no Shutdown needed.
 	}
 

--- a/server_test.go
+++ b/server_test.go
@@ -122,9 +122,9 @@ func ExampleHTTPServer() {
 	_ = r.Run(ctx)
 
 	// Output:
-	// level=INFO msg=listening runnable=httpserver addr=127.0.0.1:8080
-	// level=INFO msg="shutting down" runnable=httpserver
-	// level=INFO msg=stopped runnable=httpserver
+	// level=INFO msg="httpserver: listening" addr=127.0.0.1:8080
+	// level=INFO msg="httpserver: shutting down"
+	// level=INFO msg="httpserver: stopped"
 }
 
 func ExampleHTTPServer_error() {
@@ -141,6 +141,6 @@ func ExampleHTTPServer_error() {
 	_ = r.Run(ctx)
 
 	// Output:
-	// level=INFO msg=listening runnable=httpserver addr=INVALID
-	// level=INFO msg="stopped with error" runnable=httpserver error="listen tcp: address INVALID: missing port in address"
+	// level=INFO msg="httpserver: listening" addr=INVALID
+	// level=INFO msg="httpserver: stopped with error" error="listen tcp: address INVALID: missing port in address"
 }

--- a/signals.go
+++ b/signals.go
@@ -39,7 +39,7 @@ func (s *signal) Run(ctx context.Context) error {
 		defer ossignal.Reset(s.signals...)
 
 		sig := <-sigChan
-		logger.Info("received signal", "runnable", s.name, "signal", sig)
+		logger.Info(s.name+": received signal", "signal", sig)
 		cancelFunc()
 	}()
 

--- a/testing_test.go
+++ b/testing_test.go
@@ -20,9 +20,9 @@ func newDummyRunnable() *dummyRunnable {
 type dummyRunnable struct{}
 
 func (r *dummyRunnable) Run(ctx context.Context) error {
-	logger.Info("started", "runnable", runnableName(r))
+	logger.Info(runnableName(r) + ": started")
 	<-ctx.Done()
-	logger.Info("stopped", "runnable", runnableName(r))
+	logger.Info(runnableName(r) + ": stopped")
 	return ctx.Err()
 }
 


### PR DESCRIPTION

Log messages now include the full composed name as a prefix, making them scannable without reading structured fields. The `runnable=` field is dropped.

Before:
```
level=INFO msg=started runnable=manager/httpserver
level=INFO msg="starting shutdown" runnable=manager reason="context cancelled"
```

After:
```
level=INFO msg="manager/httpserver: started"
level=INFO msg="manager: starting shutdown" reason="context cancelled"
```

Also normalized `Manager()` constructor to set `name: "manager"` directly, making `runnableName()` a simple one-liner like all other wrappers.